### PR TITLE
Make request for iOS simulator build and download build products.

### DIFF
--- a/build-automation.py
+++ b/build-automation.py
@@ -7,6 +7,8 @@ from modules.helpers import *
 from modules.request_helpers import *
 from modules.build import *
 from modules.tam_publish import *
+from modules.download import *
+from modules.constants import *
 
 # print '---------------------------'
 # print 'Number of arguments:', len(sys.argv), 'arguments.'
@@ -16,9 +18,11 @@ from modules.tam_publish import *
 def main(argv):
 
 	settings =  Settings().load_settings(argv)
+	resources = build(settings)
+	device_resources = list(filter(lambda x: x['type'] == kBuildType.DEVICE, resources))
 
-	upload_tam(settings, { 'Content-Type': 'application/json; charset=UTF-8' }, build(settings))
-
+	upload_tam(settings, { 'Content-Type': 'application/json; charset=UTF-8' }, device_resources)
+	download_resources(resources, settings)
 	printf('DONE')
 
 if __name__ == '__main__':

--- a/modules/build.py
+++ b/modules/build.py
@@ -7,6 +7,7 @@ import glob
 from modules.settings import *
 from modules.helpers import *
 from modules.request_helpers import *
+from modules.constants import *
 
 try:
 	from urlparse import urlparse
@@ -15,7 +16,7 @@ except ImportError:
 
 def build(settings):
 
-	__file_path = settings.appid + '.zip';
+	__file_path = settings.appid + '.zip'
 	__search_patterns = ['../*/'+ __file_path , '../**/*/*/'+ __file_path,'../**/*/'+ __file_path, './**/*/'+ __file_path]
 
 	project_files = []
@@ -29,14 +30,26 @@ def build(settings):
 
 	printf('Uploading Package ...')
 	printf('File - ', project_files[0])
-
 	targetUrl = urlparse('{0}/{1}/projects/importProject/{2}'.format(settings.server_api_url, settings.appid, settings.project_name_url_encoded))
-	resp, content = do_post(targetUrl.geturl(), headers=headers, body=open(project_files[0], 'rb'))
+	resp, content = do_post(targetUrl.geturl(), headers=dict_merge(headers, {'Content-Type': 'application/json'}), body=open(project_files[0], 'rb'))
 
-	printf('Building ...')
+	printf('Building for device ...')
+	result = []
+	resource = _send_build_request(settings, kBuildType.DEVICE, headers=dict_merge(headers, {'Content-Type': 'application/json'}))
+	result.extend(resource)
 
+	printf('Building for simulator ...')
+	resource = _send_build_request(settings, kBuildType.SIMULATOR, headers=dict_merge(headers, {'Content-Type': 'application/json'}))
+	result.extend(resource)
+
+	printf('Resources: ', result)
+
+	return result
+
+def _send_build_request(settings, type, headers):
 	targetUrl = urlparse('{0}/{1}/build/{2}'.format(settings.server_api_url, settings.appid, settings.project_name_url_encoded))
-	resp, content = do_post(targetUrl.geturl(), headers=dict_merge(headers, {'Content-Type': 'application/json'}), body=json.dumps(settings.configuration['build']))
+	configuration = settings.configuration['build'][type]
+	resp, content = do_post(targetUrl.geturl(), headers=dict_merge(headers, {'Content-Type': 'application/json'}), body=json.dumps(configuration))
 
 	json_response=json.loads(content)
 
@@ -45,9 +58,6 @@ def build(settings):
 		quit()
 
 	build_result = json_response['ResultsByTarget']['Build']
-
-	resource = list(map(lambda x: { 'url': x['FullPath'], 'platform': x['Platform']}, list(filter(lambda x: x['Disposition'] == 'BuildResult', build_result['Items']))))
-
-	printf('Resources: ', resource)
+	resource = list(map(lambda x: { 'url': x['FullPath'], 'platform': x['Platform'], 'type': type}, list(filter(lambda x: x['Disposition'] == 'BuildResult', build_result['Items']))))
 
 	return resource

--- a/modules/constants.py
+++ b/modules/constants.py
@@ -1,0 +1,3 @@
+class kBuildType:
+	DEVICE = "device"
+	SIMULATOR = "simulator"

--- a/modules/download.py
+++ b/modules/download.py
@@ -1,0 +1,13 @@
+import sys
+from modules.request_helpers import *
+from modules.constants import *
+
+def download_resources(resources, settings):
+	http = httplib2.Http()
+	printf('Downloading resources ...')
+	for r in resources:
+		filename = settings.configuration['filenames'][r['type']][r['platform']]
+
+		resp, content = http.request(r['url'], "GET")
+		with open(filename, 'wb') as f:
+			f.write(content)


### PR DESCRIPTION
**Description:**
Implement additional request for `iOS` simulator build and downloading of all build products. This change will help the testing process by giving the ability of an existing jenking job to deliver build artifacts to the expected place by the test jobs.